### PR TITLE
feat: hyproled now works when called under hypridle

### DIFF
--- a/hyproled
+++ b/hyproled
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 shift=false; invert=false; monitor=0
 fill_color='0.0,0.0,0.0,1.0'
 
@@ -7,7 +8,7 @@ SHADER_FILE="/dev/shm/hyproled_shader.glsl"
 
 show_help(){
   cat <<EOF
-Usage: $(basename $0) [OPTION]... [off]
+Usage: $(basename "$0") [OPTION]... [off]
 
 Hyprland shader utility to prevent OLED burn in.
 
@@ -25,34 +26,29 @@ Argument:
 EOF
 }
 
+# Disable shader
 if [[ $1 == off ]]; then
   hyprctl keyword decoration:screen_shader ""
   exit 0
 fi
 
+# Parse options
 while getopts ":a:ism:h" opt; do
   case $opt in
     a) area=$OPTARG ;;
-    s) shift=true ;;
     i) invert=true ;;
+    s) shift=true ;;
     m) monitor=$OPTARG ;;
-    h) show_help; exit ;;
+    h) show_help; exit 0 ;;
     *) show_help; exit 1 ;;
   esac
 done
-shift $((OPTIND-1))
 
-
-# Only use shift if -s is passed
+# Compute shift offset
 if $shift; then
-  # Read last state, default to 0
-  if [[ -f $STATE_FILE ]]; then
-    last_shift=$(<"$STATE_FILE")
-  else
-    last_shift=0
-  fi
-  # Toggle state
-  if [[ $last_shift -eq 0 ]]; then
+  last_shift=0
+  [[ -f $STATE_FILE ]] && read -r last_shift < "$STATE_FILE"
+  if (( last_shift == 0 )); then
     shift_offset=1
     echo 1 > "$STATE_FILE"
   else
@@ -63,10 +59,8 @@ else
   shift_offset=0
 fi
 
-
-
-# Base shader header
-cat > "$SHADER_FILE" <<EOF
+# Build shader content in one heredoc (into a variable)
+shader=$(cat <<EOF
 #version 300 es
 precision highp float;
 in vec2 v_texcoord;
@@ -78,28 +72,37 @@ void main(){
   if(wl_output != ${monitor}) { fragColor = orig; return; }
   vec2 fc = gl_FragCoord.xy;
   bool even = mod(fc.x + fc.y + float(${shift_offset}),2.0)==0.0;
+  vec4 pixel = even ? orig : vec4(${fill_color});
 EOF
+)
 
-echo "  vec4 pixel = even ? orig : vec4(${fill_color});" >> "$SHADER_FILE"
-
-# Region logic
+# Append region logic into the same variable
 if [[ -n $area ]]; then
   if [[ $area =~ ^([0-9]+):([0-9]+):([0-9]+):([0-9]+)$ ]]; then
-    read x y w h <<< "${BASH_REMATCH[*]:1:4}"
-    echo "  bool inRegion = (fc.x >= ${x}.0 && fc.x <= (${x}.0+${w}.0) && fc.y >= ${y}.0 && fc.y <= (${y}.0+${h}.0));" >> "$SHADER_FILE"
+    read -r x y w h <<< "${BASH_REMATCH[*]:1:4}"
+    shader+=$'\n'
+    shader+="  bool inRegion = (fc.x >= ${x}.0 && fc.x <= (${x}.0+${w}.0) && fc.y >= ${y}.0 && fc.y <= (${y}.0+${h}.0));"
+    shader+=$'\n'
     if $invert; then
-      echo "  fragColor = inRegion ? orig : pixel;" >> "$SHADER_FILE"
+      shader+="  fragColor = inRegion ? orig : pixel;"
     else
-      echo "  fragColor = inRegion ? pixel : orig;" >> "$SHADER_FILE"
+      shader+="  fragColor = inRegion ? pixel : orig;"
     fi
-    echo "}" >> "$SHADER_FILE"
+    shader+=$'\n'
+    shader+="}"
   else
-    echo "Invalid area format, use x:y:w:h" >&2; exit 1
+    echo "Invalid area format, use x:y:w:h" >&2
+    exit 1
   fi
 else
-  echo "  fragColor = pixel;" >> "$SHADER_FILE"
-  echo "}" >> "$SHADER_FILE"
+  shader+=$'\n'
+  shader+="  fragColor = pixel;"
+  shader+=$'\n'
+  shader+="}"
 fi
 
+# Single write: printf the entire shader in one operation
+printf '%s\n' "$shader" > "$SHADER_FILE"
 
+# Apply the shader
 hyprctl keyword decoration:screen_shader "$SHADER_FILE"


### PR DESCRIPTION
Changed hyproled to make the entire file string FIRST then write it to the shader file. Seems to solve the hypridle issue and still seems to work as intended. Don't have multiple monitors so I cannot test the -m param. Everything else seems to work. I have no idea the underlying issue causing the doubled-up writes RE my opened issue, but this solves it by ensuring everything is done with a single write. Needs review to make sure everything still works before accepting.